### PR TITLE
fix: Refresh the calendar widget's current date

### DIFF
--- a/Sapphire.xcodeproj/project.pbxproj
+++ b/Sapphire.xcodeproj/project.pbxproj
@@ -127,6 +127,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		DA46CF802DCBCA0100F00EC5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA46CF6E2DCBCA0000F00EC5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA46CF752DCBCA0000F00EC5;
+			remoteInfo = Sapphire;
+		};
 		DA7C49AF2E15D3800049937A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DA46CF6E2DCBCA0000F00EC5 /* Project object */;
@@ -180,6 +187,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		DA46CF872DCBCA0100F00EC5 /* SapphireTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SapphireTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA262ADF2EA4841B0027CA69 /* OSD.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OSD.framework; path = ../../../../System/Library/PrivateFrameworks/OSD.framework; sourceTree = "<group>"; };
 		DA262AE22EA484A70027CA69 /* Sapphire.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = Sapphire.xcodeproj; sourceTree = "<group>"; };
 		DA262AE52EA485150027CA69 /* CoreDisplay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreDisplay.framework; path = ../../../../System/Library/Frameworks/CoreDisplay.framework; sourceTree = "<group>"; };
@@ -379,6 +387,11 @@
 /* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		DA46CF7F2DCBCA0100F00EC5 /* SapphireTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = SapphireTests;
+			sourceTree = "<group>";
+		};
 		DA183FC92E122AF30056667D /* Sapphire */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -426,6 +439,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		DA46CF842DCBCA0100F00EC5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DA452EAC2EAA57C90070E5C9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			files = (
@@ -486,6 +506,7 @@
 		DA46CF6D2DCBCA0000F00EC5 = {
 			isa = PBXGroup;
 			children = (
+				DA46CF7F2DCBCA0100F00EC5 /* SapphireTests */,
 				DA91BDE72E773A9D001E7836 /* SystemSounds */,
 				DAF7D8AD2E20801E00AB0820 /* SwiftProtobuf_SwiftProtobuf.bundle */,
 				DA183FC92E122AF30056667D /* Sapphire */,
@@ -506,6 +527,7 @@
 			isa = PBXGroup;
 			children = (
 				DA46CF762DCBCA0000F00EC5 /* Sapphire.app */,
+				DA46CF872DCBCA0100F00EC5 /* SapphireTests.xctest */,
 				DA7C49802E15CCA50049937A /* libNearbyShare.dylib */,
 				DAA7D9D42E8633B20032748B /* abt */,
 				DA452EAF2EAA57C90070E5C9 /* com.shariq.sapphireHelper */,
@@ -736,6 +758,27 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		DA46CF862DCBCA0100F00EC5 /* SapphireTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA46CF8A2DCBCA0100F00EC5 /* Build configuration list for PBXNativeTarget "SapphireTests" */;
+			buildPhases = (
+				DA46CF832DCBCA0100F00EC5 /* Sources */,
+				DA46CF842DCBCA0100F00EC5 /* Frameworks */,
+				DA46CF852DCBCA0100F00EC5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DA46CF812DCBCA0100F00EC5 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				DA46CF7F2DCBCA0100F00EC5 /* SapphireTests */,
+			);
+			name = SapphireTests;
+			productName = SapphireTests;
+			productReference = DA46CF872DCBCA0100F00EC5 /* SapphireTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		DA452EAE2EAA57C90070E5C9 /* com.shariq.sapphireHelper */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA452EB32EAA57C90070E5C9 /* Build configuration list for PBXNativeTarget "com.shariq.sapphireHelper" */;
@@ -841,6 +884,9 @@
 				LastSwiftUpdateCheck = 2600;
 				LastUpgradeCheck = 2650;
 				TargetAttributes = {
+					DA46CF862DCBCA0100F00EC5 = {
+						CreatedOnToolsVersion = 26.0;
+					};
 					DA452EAE2EAA57C90070E5C9 = {
 						CreatedOnToolsVersion = 26.0.1;
 						LastSwiftMigration = 2600;
@@ -886,6 +932,7 @@
 			projectRoot = "";
 			targets = (
 				DA46CF752DCBCA0000F00EC5 /* Sapphire */,
+				DA46CF862DCBCA0100F00EC5 /* SapphireTests */,
 				DA7C497F2E15CCA50049937A /* NearbyShare */,
 				DAA7D9D32E8633B20032748B /* abt */,
 				DA452EAE2EAA57C90070E5C9 /* com.shariq.sapphireHelper */,
@@ -894,6 +941,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		DA46CF852DCBCA0100F00EC5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DA46CF742DCBCA0000F00EC5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			files = (
@@ -989,6 +1043,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		DA46CF832DCBCA0100F00EC5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DA452EAB2EAA57C90070E5C9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
@@ -1029,6 +1090,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		DA46CF812DCBCA0100F00EC5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA46CF752DCBCA0000F00EC5 /* Sapphire */;
+			targetProxy = DA46CF802DCBCA0100F00EC5 /* PBXContainerItemProxy */;
+		};
 		DA7C49B02E15D3800049937A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DA7C497F2E15CCA50049937A /* NearbyShare */;
@@ -1037,6 +1103,52 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		DA46CF882DCBCA0100F00EC5 /* Debug configuration for PBXNativeTarget "SapphireTests" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KVQFWJ7C7S;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cshariq.SapphireTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sapphire.app/Contents/MacOS/Sapphire";
+			};
+			name = Debug;
+		};
+		DA46CF892DCBCA0100F00EC5 /* Release configuration for PBXNativeTarget "SapphireTests" */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = KVQFWJ7C7S;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cshariq.SapphireTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Sapphire.app/Contents/MacOS/Sapphire";
+			};
+			name = Release;
+		};
 		DA452EB42EAA57C90070E5C9 /* Debug configuration for PBXNativeTarget "com.shariq.sapphireHelper" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1476,6 +1588,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		DA46CF8A2DCBCA0100F00EC5 /* Build configuration list for PBXNativeTarget "SapphireTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA46CF882DCBCA0100F00EC5 /* Debug configuration for PBXNativeTarget "SapphireTests" */,
+				DA46CF892DCBCA0100F00EC5 /* Release configuration for PBXNativeTarget "SapphireTests" */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		DA452EB32EAA57C90070E5C9 /* Build configuration list for PBXNativeTarget "com.shariq.sapphireHelper" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Sapphire/Services/Calendar/CalendarViewModel.swift
+++ b/Sapphire/Services/Calendar/CalendarViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import AppKit
 import SwiftUI
 
 struct MonthGridItem: Identifiable {
@@ -22,21 +23,45 @@ class InteractiveCalendarViewModel: ObservableObject {
         }
     }
     @Published var monthGrid: [MonthGridItem] = []
+    @Published private(set) var today: Date
 
-    let today: Date = Calendar.current.startOfDay(for: Date())
+    private let calendar: () -> Calendar
+    private let now: () -> Date
+    private var notificationObservers: [(center: NotificationCenter, token: NSObjectProtocol)] = []
 
     var selectedMonthAbbreviated: String {
         selectedDate.format(as: "MMM")
     }
 
-    init() {
-        self.selectedDate = self.today
-        generateDates()
-        generateMonthGrid()
+    init(
+        calendar: @escaping () -> Calendar = { Calendar.current },
+        now: @escaping () -> Date = { Date() },
+        notificationCenter: NotificationCenter = .default,
+        workspaceNotificationCenter: NotificationCenter = NSWorkspace.shared.notificationCenter
+    ) {
+        self.calendar = calendar
+        self.now = now
+
+        let currentCalendar = calendar()
+        let currentDay = currentCalendar.startOfDay(for: now())
+        self.today = currentDay
+        self.selectedDate = currentDay
+
+        generateDates(using: currentCalendar)
+        generateMonthGrid(using: currentCalendar)
+        observeCurrentDayChanges(
+            notificationCenter: notificationCenter,
+            workspaceNotificationCenter: workspaceNotificationCenter
+        )
     }
 
-    private func generateDates() {
-        let calendar = Calendar.current
+    deinit {
+        notificationObservers.forEach { observer in
+            observer.center.removeObserver(observer.token)
+        }
+    }
+
+    private func generateDates(using calendar: Calendar) {
         let dateRange = -90...90
 
         self.dates = dateRange.compactMap { dayOffset in
@@ -44,8 +69,8 @@ class InteractiveCalendarViewModel: ObservableObject {
         }
     }
 
-    private func generateMonthGrid() {
-        let calendar = Calendar.current
+    private func generateMonthGrid(using calendar: Calendar? = nil) {
+        let calendar = calendar ?? self.calendar()
         guard let monthInterval = calendar.dateInterval(of: .month, for: selectedDate),
               let firstDayOfMonth = monthInterval.start as Date?,
               let firstWeekday = calendar.ordinality(of: .weekday, in: .weekOfYear, for: firstDayOfMonth) else {
@@ -83,8 +108,45 @@ class InteractiveCalendarViewModel: ObservableObject {
         self.monthGrid = grid
     }
 
+    private func observeCurrentDayChanges(
+        notificationCenter: NotificationCenter,
+        workspaceNotificationCenter: NotificationCenter
+    ) {
+        observe(
+            [.NSCalendarDayChanged, .NSSystemClockDidChange, .NSSystemTimeZoneDidChange,
+             NSApplication.didBecomeActiveNotification],
+            in: notificationCenter
+        )
+        observe([NSWorkspace.didWakeNotification], in: workspaceNotificationCenter)
+    }
+
+    private func observe(_ names: [Notification.Name], in center: NotificationCenter) {
+        for name in names {
+            let token = center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.refreshCurrentDay(for: notification.name)
+            }
+            notificationObservers.append((center, token))
+        }
+    }
+
+    private func refreshCurrentDay(for notificationName: Notification.Name) {
+        let calendar = calendar()
+        let currentDay = calendar.startOfDay(for: now())
+        guard currentDay != today else { return }
+
+        let wasFollowingToday = selectedDate == today
+        today = currentDay
+        generateDates(using: calendar)
+
+        if wasFollowingToday {
+            selectedDate = currentDay
+        } else if notificationName == .NSSystemTimeZoneDidChange {
+            generateMonthGrid(using: calendar)
+        }
+    }
+
     func datesInWeek(for date: Date) -> [Date] {
-        let calendar = Calendar.current
+        let calendar = calendar()
         guard let weekInterval = calendar.dateInterval(of: .weekOfYear, for: date) else { return [] }
         var dates: [Date] = []
         var currentDate = weekInterval.start
@@ -98,6 +160,6 @@ class InteractiveCalendarViewModel: ObservableObject {
     }
 
     func selectDate(_ date: Date) {
-        self.selectedDate = Calendar.current.startOfDay(for: date)
+        self.selectedDate = calendar().startOfDay(for: date)
     }
 }

--- a/SapphireTests/CalendarViewModelTests.swift
+++ b/SapphireTests/CalendarViewModelTests.swift
@@ -1,0 +1,180 @@
+//
+//  CalendarViewModelTests.swift
+//  SapphireTests
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import Sapphire
+
+@MainActor
+struct CalendarViewModelTests {
+    @Test func dayChangeAdvancesCurrentSelectionAndDateStrip() {
+        let calendarSource = CalendarSource(timeZone: timeZone("America/Los_Angeles"))
+        let clock = TestClock(date(2026, 8, 11, hour: 12, calendar: calendarSource.calendar))
+        let notificationCenter = NotificationCenter()
+        let viewModel = makeViewModel(
+            calendarSource: calendarSource,
+            clock: clock,
+            notificationCenter: notificationCenter
+        )
+
+        let august12 = date(2026, 8, 12, calendar: calendarSource.calendar)
+        clock.now = date(2026, 8, 12, hour: 12, calendar: calendarSource.calendar)
+        notificationCenter.post(name: .NSCalendarDayChanged, object: nil)
+
+        #expect(viewModel.today == august12)
+        #expect(viewModel.selectedDate == august12)
+        #expect(viewModel.dates.count == 181)
+        #expect(viewModel.dates[90] == august12)
+    }
+
+    @Test func dayChangePreservesExplicitSelection() {
+        let calendarSource = CalendarSource(timeZone: timeZone("America/Los_Angeles"))
+        let clock = TestClock(date(2026, 8, 11, hour: 12, calendar: calendarSource.calendar))
+        let notificationCenter = NotificationCenter()
+        let viewModel = makeViewModel(
+            calendarSource: calendarSource,
+            clock: clock,
+            notificationCenter: notificationCenter
+        )
+        let explicitSelection = date(2026, 8, 8, calendar: calendarSource.calendar)
+        viewModel.selectDate(explicitSelection)
+
+        let august12 = date(2026, 8, 12, calendar: calendarSource.calendar)
+        clock.now = date(2026, 8, 12, hour: 12, calendar: calendarSource.calendar)
+        notificationCenter.post(name: .NSCalendarDayChanged, object: nil)
+
+        #expect(viewModel.today == august12)
+        #expect(viewModel.selectedDate == explicitSelection)
+        #expect(viewModel.dates[90] == august12)
+    }
+
+    @Test func timeZoneChangeUsesNewLocalStartOfDay() {
+        let calendarSource = CalendarSource(timeZone: timeZone("America/Los_Angeles"))
+        let instant = Date(timeIntervalSince1970: 1_786_494_600) // 2026-08-12 00:30:00 UTC
+        let clock = TestClock(instant)
+        let notificationCenter = NotificationCenter()
+        let viewModel = makeViewModel(
+            calendarSource: calendarSource,
+            clock: clock,
+            notificationCenter: notificationCenter
+        )
+
+        let oldToday = calendarSource.calendar.startOfDay(for: instant)
+        calendarSource.timeZone = timeZone("Asia/Tokyo")
+        let newToday = calendarSource.calendar.startOfDay(for: instant)
+        notificationCenter.post(name: .NSSystemTimeZoneDidChange, object: nil)
+
+        #expect(newToday != oldToday)
+        #expect(viewModel.today == newToday)
+        #expect(viewModel.selectedDate == newToday)
+        #expect(viewModel.dates[90] == newToday)
+    }
+
+    @Test func unchangedDayKeepsSelectionAndGeneratedRangeStable() {
+        let calendarSource = CalendarSource(timeZone: timeZone("America/Los_Angeles"))
+        let clock = TestClock(date(2026, 8, 11, hour: 9, calendar: calendarSource.calendar))
+        let notificationCenter = NotificationCenter()
+        let viewModel = makeViewModel(
+            calendarSource: calendarSource,
+            clock: clock,
+            notificationCenter: notificationCenter
+        )
+        let originalToday = viewModel.today
+        let originalSelection = viewModel.selectedDate
+        let originalDates = viewModel.dates
+        let originalGridIDs = viewModel.monthGrid.map(\.id)
+
+        clock.now = date(2026, 8, 11, hour: 21, calendar: calendarSource.calendar)
+        notificationCenter.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+
+        #expect(viewModel.today == originalToday)
+        #expect(viewModel.selectedDate == originalSelection)
+        #expect(viewModel.dates == originalDates)
+        #expect(viewModel.monthGrid.map(\.id) == originalGridIDs)
+    }
+
+    @Test func notificationObserversDoNotRetainReleasedViewModel() {
+        let calendarSource = CalendarSource(timeZone: timeZone("America/Los_Angeles"))
+        let clock = TestClock(date(2026, 8, 11, hour: 12, calendar: calendarSource.calendar))
+        let notificationCenter = NotificationCenter()
+        let workspaceNotificationCenter = NotificationCenter()
+        weak var weakViewModel: InteractiveCalendarViewModel?
+
+        do {
+            let viewModel = makeViewModel(
+                calendarSource: calendarSource,
+                clock: clock,
+                notificationCenter: notificationCenter,
+                workspaceNotificationCenter: workspaceNotificationCenter
+            )
+            weakViewModel = viewModel
+            #expect(weakViewModel != nil)
+        }
+
+        let readsAfterRelease = clock.readCount
+        notificationCenter.post(name: .NSCalendarDayChanged, object: nil)
+        workspaceNotificationCenter.post(name: NSWorkspace.didWakeNotification, object: nil)
+
+        #expect(weakViewModel == nil)
+        #expect(clock.readCount == readsAfterRelease)
+    }
+
+    private func makeViewModel(
+        calendarSource: CalendarSource,
+        clock: TestClock,
+        notificationCenter: NotificationCenter,
+        workspaceNotificationCenter: NotificationCenter = NotificationCenter()
+    ) -> InteractiveCalendarViewModel {
+        InteractiveCalendarViewModel(
+            calendar: { calendarSource.calendar },
+            now: { clock.currentDate() },
+            notificationCenter: notificationCenter,
+            workspaceNotificationCenter: workspaceNotificationCenter
+        )
+    }
+
+    private func date(
+        _ year: Int,
+        _ month: Int,
+        _ day: Int,
+        hour: Int = 0,
+        calendar: Calendar
+    ) -> Date {
+        calendar.date(from: DateComponents(year: year, month: month, day: day, hour: hour))!
+    }
+
+    private func timeZone(_ identifier: String) -> TimeZone {
+        TimeZone(identifier: identifier)!
+    }
+}
+
+private final class CalendarSource {
+    var timeZone: TimeZone
+
+    var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return calendar
+    }
+
+    init(timeZone: TimeZone) {
+        self.timeZone = timeZone
+    }
+}
+
+private final class TestClock {
+    var now: Date
+    private(set) var readCount = 0
+
+    init(_ now: Date) {
+        self.now = now
+    }
+
+    func currentDate() -> Date {
+        readCount += 1
+        return now
+    }
+}


### PR DESCRIPTION
Make the existing `InteractiveCalendarViewModel` own current-day refresh behavior instead of leaving `today` as an immutable initialization snapshot. Observe the system calendar-day change and relevant app/wake or clock/time-zone lifecycle notifications already used elsewhere in Sapphire, then recompute the calendar-normalized current day and rebuild the date range when necessary. If the selection still represents the formerly current day, advance it to the new current day so the compact widget recenters and refreshes its schedule through its existing `selectedDate` observation; if the user deliberately selected another day, preserve that selection while updating the model's current-day reference and generated dates. The compact calendar widget can continue highlighting the previous day after the system date advances; the reported example showed August 11 selected when the system date was August 12. `InteractiveCalendarViewModel` computes `today` once during initialization, generates its date strip from that snapshot, and is retained by the notch and lock-screen widget hosts, so a long-running app can keep stale calendar state across midnight or wake. The expanded calendar creates its own view model when presented and may therefore appear correct even while the persistent compact widget is stale, which explains the maintainer's follow-up without making the compact-widget reproduction ambiguous. There are no assignees, claims, competing open PRs, or prior closed-unmerged attempts in the supplied issue evidence.

Testing: Initialize the view model with a fixed August 11 local date, advance the supplied current time to August 12, deliver the day-change refresh, and verify `today`, `selectedDate`, and the generated date strip all move to August 12; Select a non-current date before advancing the supplied time, refresh the current day, and verify the explicit selection is preserved while `today` and the date strip update.

Fixes #30
