### PR TITLE
Harden updater, privileged helper, and AppleScript/shell call sites

### DIFF
--- a/Sapphire/App Settings/UpdateChecker.swift
+++ b/Sapphire/App Settings/UpdateChecker.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import AppKit
+import Security
 
 let currentAppVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0"
 
@@ -373,6 +374,11 @@ class UpdateChecker: NSObject, ObservableObject, URLSessionDownloadDelegate {
                 }
                 let fullNewAppPath = tempUnzipDirectory.appendingPathComponent(newAppPath).path
 
+                // Verify the downloaded bundle is validly signed by the same developer
+                // BEFORE it replaces the running app (potentially as root). Transport
+                // security (TLS to GitHub) alone does not guarantee payload integrity.
+                try Self.verifyDownloadedApp(at: fullNewAppPath)
+
                 let currentAppPath = Bundle.main.bundlePath
                 let processID = String(ProcessInfo.processInfo.processIdentifier)
                 let userWritable = await MainActor.run { self.isInstallPathUserWritable() }
@@ -408,6 +414,54 @@ class UpdateChecker: NSObject, ObservableObject, URLSessionDownloadDelegate {
                 }
             }
         }
+    }
+
+    // MARK: - Update Integrity Verification
+
+    /// Validates that the downloaded `.app` carries a well-formed Apple-anchored
+    /// signature and, when the running app is itself team-signed, that the update
+    /// is signed by the *same* Team ID. This pins updates to the original developer
+    /// and prevents a spoofed/tampered release from being installed.
+    nonisolated private static func verifyDownloadedApp(at appPath: String) throws {
+        let appURL = URL(fileURLWithPath: appPath)
+
+        var staticCode: SecStaticCode?
+        let createStatus = SecStaticCodeCreateWithPath(appURL as CFURL, [], &staticCode)
+        guard createStatus == errSecSuccess, let code = staticCode else {
+            throw NSError(domain: "UpdateError", code: 10, userInfo: [NSLocalizedDescriptionKey: "Could not read the downloaded update's code signature. Installation aborted."])
+        }
+
+        var requirement: SecRequirement?
+        if let team = currentAppTeamID(), !team.isEmpty {
+            // Signed distribution build: require Apple anchor + matching Team ID.
+            let requirementText = "anchor apple generic and certificate leaf[subject.OU] = \"\(team)\""
+            let reqStatus = SecRequirementCreateWithString(requirementText as CFString, [], &requirement)
+            guard reqStatus == errSecSuccess, requirement != nil else {
+                throw NSError(domain: "UpdateError", code: 11, userInfo: [NSLocalizedDescriptionKey: "Could not build the update verification policy. Installation aborted."])
+            }
+        }
+        // If the running app has no Team ID (ad-hoc/development build) we cannot pin
+        // to a developer, so we fall back to verifying the signature is at least
+        // internally valid (requirement == nil below).
+
+        let flags = SecCSFlags(rawValue: kSecCSCheckAllArchitectures | kSecCSCheckNestedCode)
+        let validStatus = SecStaticCodeCheckValidity(code, flags, requirement)
+        guard validStatus == errSecSuccess else {
+            let message = (SecCopyErrorMessageString(validStatus, nil) as String?) ?? "unknown error (\(validStatus))"
+            throw NSError(domain: "UpdateError", code: 12, userInfo: [NSLocalizedDescriptionKey: "The downloaded update failed code-signature verification: \(message). Installation aborted."])
+        }
+    }
+
+    /// Team Identifier of the currently running application, if it is team-signed.
+    nonisolated private static func currentAppTeamID() -> String? {
+        var code: SecCode?
+        guard SecCodeCopySelf([], &code) == errSecSuccess, let selfCode = code else { return nil }
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(selfCode, [], &staticCode) == errSecSuccess, let sc = staticCode else { return nil }
+        var info: CFDictionary?
+        guard SecCodeCopySigningInformation(sc, SecCSFlags(rawValue: kSecCSSigningInformation), &info) == errSecSuccess,
+              let dict = info as? [String: Any] else { return nil }
+        return dict[kSecCodeInfoTeamIdentifier as String] as? String
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {

--- a/Sapphire/Services/Bluetooth/logReader.sh
+++ b/Sapphire/Services/Bluetooth/logReader.sh
@@ -51,7 +51,7 @@ else
     type=$2
     id=$3
     
-    data=`$syslog $type -u $id --process SpringBoard -m '"Accessory Category" = Pencil;' -T SpringBoard`
+    data=`"$syslog" "$type" -u "$id" --process SpringBoard -m '"Accessory Category" = Pencil;' -T SpringBoard`
     batt=`echo "$data"|grep "Current Capacity"|grep -o "[0-9]*"|sed -n '$p'`
     stat=`echo "$data"|grep "Is Charging"|grep -o "[0-9]*"|sed -n '$p'`
     model=`echo "$data"|grep "Product ID"|grep -o "[0-9]*"|sed -n '$p'`

--- a/Sapphire/Services/Miscellaneous/NotificationManager.swift
+++ b/Sapphire/Services/Miscellaneous/NotificationManager.swift
@@ -78,6 +78,16 @@ class iMessageActionManager {
     private var audioPlayer: AVPlayer?
     private var chatDbConnection: Connection?
     private init() { setupChatDatabaseConnection() }
+
+    /// Escapes a string for safe interpolation inside an AppleScript double-quoted
+    /// literal. Backslash must be escaped first, then the double quote — otherwise a
+    /// trailing/embedded backslash in remote-influenced message or contact text can
+    /// unbalance the escaping and break out of the string (AppleScript injection).
+    private func escapeForAppleScript(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
     private func setupChatDatabaseConnection() {
         let chatDbPath = ("~/Library/Messages/chat.db" as NSString).expandingTildeInPath
         do { chatDbConnection = try Connection(chatDbPath, readonly: true) } catch { print("iMessageActionManager: ERROR: Could not connect to chat.db: \(error)") }
@@ -86,8 +96,8 @@ class iMessageActionManager {
         Task(priority: .userInitiated) {
             let contactIdentifiers = await _getContactIdentifiers(forName: recipientName)
             guard !contactIdentifiers.isEmpty else { return }
-            let identifiersString = contactIdentifiers.map { "\"\($0)\"" }.joined(separator: ", ")
-            let sanitizedMessage = message.replacingOccurrences(of: "\"", with: "\\\"")
+            let identifiersString = contactIdentifiers.map { "\"\(escapeForAppleScript($0))\"" }.joined(separator: ", ")
+            let sanitizedMessage = escapeForAppleScript(message)
             let scriptTemplate = """
             tell application "Messages"
                 set identifierList to {%@}
@@ -112,7 +122,7 @@ class iMessageActionManager {
         Task(priority: .userInitiated) {
             let contactIdentifiers = await _getContactIdentifiers(forName: recipientName)
             guard let primaryIdentifier = contactIdentifiers.first else { return }
-            let sanitizedIdentifier = primaryIdentifier.replacingOccurrences(of: "\"", with: "\\\"")
+            let sanitizedIdentifier = escapeForAppleScript(primaryIdentifier)
             let tapbackValue = tapbackType.rawValue
             let script = """
             tell application "Messages"
@@ -140,7 +150,7 @@ class iMessageActionManager {
     }
     func replyToLastMessage() { if !NSWorkspace.shared.launchApplication("Messages") { print("iMessageActionManager: Could not launch Messages.app") } }
     func markConversationAsRead(senderName: String) {
-        let sanitizedSenderName = senderName.replacingOccurrences(of: "\"", with: "\\\"")
+        let sanitizedSenderName = escapeForAppleScript(senderName)
         let script = """
         tell application "Messages"
             try

--- a/Sapphire/Services/Music/Spotify/SpotifyAppleScriptManager.swift
+++ b/Sapphire/Services/Music/Spotify/SpotifyAppleScriptManager.swift
@@ -14,6 +14,14 @@ class SpotifyAppleScriptManager {
 
     private init() {}
 
+    /// Escapes a string for safe interpolation inside an AppleScript double-quoted
+    /// literal. Backslash must be escaped first, then the double quote.
+    private func escapeForAppleScript(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
     func isAppRunning() -> Bool {
         return NSWorkspace.shared.runningApplications.contains { $0.bundleIdentifier == "com.spotify.client" }
     }
@@ -43,7 +51,7 @@ class SpotifyAppleScriptManager {
         if !isAppRunning() {
             return .requiresSpotifyAppOpen
         }
-        let script = "tell application \"Spotify\" to play track \"\(uri)\""
+        let script = "tell application \"Spotify\" to play track \"\(escapeForAppleScript(uri))\""
         let success = await runAppleScriptInBackground(script)
         return success ? .success : .failure(reason: "AppleScript command failed.")
     }

--- a/com.shariq.sapphireHelper/CodesignCheckError.swift
+++ b/com.shariq.sapphireHelper/CodesignCheckError.swift
@@ -14,6 +14,19 @@ enum CodesignCheckError: Error {
 
 struct CodesignCheck {
 
+    /// Validate a client identified by its XPC connection's audit token. Preferred
+    /// over the PID-based variant, which is subject to a PID-reuse race.
+    public static func codeSigningMatches(auditToken: audit_token_t) throws -> Bool {
+        // Prefer same Team ID so Development and Developer ID builds from the
+        // same team can talk. Fall back to exact certificate equality.
+        if let selfTeam = try teamID(forStaticCode: try requireSelfStaticCode()),
+           let clientTeam = try teamID(forStaticCode: try requireStaticCode(forAuditToken: auditToken)),
+           !selfTeam.isEmpty, !clientTeam.isEmpty {
+            return selfTeam == clientTeam
+        }
+        return try self.codeSigningCertificatesForSelf() == self.codeSigningCertificates(forAuditToken: auditToken)
+    }
+
     public static func codeSigningMatches(pid: pid_t) throws -> Bool {
         // Prefer same Team ID so Development and Developer ID builds from the
         // same team can talk. Fall back to exact certificate equality.
@@ -46,6 +59,13 @@ struct CodesignCheck {
         return code
     }
 
+    private static func requireStaticCode(forAuditToken auditToken: audit_token_t) throws -> SecStaticCode {
+        guard let code = try secStaticCode(forAuditToken: auditToken) else {
+            throw CodesignCheckError.message("SecStaticCode returned empty for audit token")
+        }
+        return code
+    }
+
     public static func codeSigningCertificatesForSelf() throws -> [SecCertificate] {
         guard let secStaticCode = try secStaticCodeSelf() else { return [] }
         return try codeSigningCertificates(forStaticCode: secStaticCode)
@@ -53,6 +73,11 @@ struct CodesignCheck {
 
     public static func codeSigningCertificates(forPID pid: pid_t) throws -> [SecCertificate] {
         guard let secStaticCode = try secStaticCode(forPID: pid) else { return [] }
+        return try codeSigningCertificates(forStaticCode: secStaticCode)
+    }
+
+    public static func codeSigningCertificates(forAuditToken auditToken: audit_token_t) throws -> [SecCertificate] {
+        guard let secStaticCode = try secStaticCode(forAuditToken: auditToken) else { return [] }
         return try codeSigningCertificates(forStaticCode: secStaticCode)
     }
 
@@ -81,6 +106,19 @@ struct CodesignCheck {
         try executeSecFunction { SecCodeCopyGuestWithAttributes(nil, [kSecGuestAttributePid: pid] as CFDictionary, [], &secCodePID) }
         guard let secCode = secCodePID else {
             throw CodesignCheckError.message("SecCode returned empty from SecCodeCopyGuestWithAttributes")
+        }
+        return try secStaticCode(forSecCode: secCode)
+    }
+
+    private static func secStaticCode(forAuditToken auditToken: audit_token_t) throws -> SecStaticCode? {
+        var token = auditToken
+        let tokenData = Data(bytes: &token, count: MemoryLayout<audit_token_t>.size)
+        var secCodeToken: SecCode?
+        try executeSecFunction {
+            SecCodeCopyGuestWithAttributes(nil, [kSecGuestAttributeAudit: tokenData] as CFDictionary, [], &secCodeToken)
+        }
+        guard let secCode = secCodeToken else {
+            throw CodesignCheckError.message("SecCode returned empty from SecCodeCopyGuestWithAttributes (audit token)")
         }
         return try secStaticCode(forSecCode: secCode)
     }

--- a/com.shariq.sapphireHelper/XPCServer.swift
+++ b/com.shariq.sapphireHelper/XPCServer.swift
@@ -28,7 +28,10 @@ class XPCServer: NSObject {
 
     private func isValidClient(forConnection connection: NSXPCConnection) -> Bool {
         do {
-            return try CodesignCheck.codeSigningMatches(pid: connection.processIdentifier)
+            // Validate via the connection's audit token rather than its PID. A PID can
+            // be reused/recycled between the check and use (TOCTOU race), whereas the
+            // audit token unambiguously identifies the peer of this specific connection.
+            return try CodesignCheck.codeSigningMatches(auditToken: connection.auditToken)
         } catch {
             NSLog("[SMJBS]: Code signing check failed with error: \(error)")
             return false


### PR DESCRIPTION
Security hardening across the app and the privileged helper. No behavior change for normal use; each change closes a trust-boundary weakness.

UpdateChecker.swift
- Verify the downloaded .app’s code signature before it replaces the running app (previously trusted TLS-to-GitHub alone). Uses SecStaticCodeCheckValidity with nested-code + all-architectures checks and, when the running app is team-signed, pins the update to the same Team ID (anchor apple generic + leaf subject.OU). Aborts the install (including the admin/root path) on any verification failure.

com.shariq.sapphireHelper (XPCServer.swift, CodesignCheckError.swift)
- Validate XPC clients by the connection’s audit token instead of its PID, closing the PID-reuse TOCTOU race. Adds audit-token variants of the code-signing checks via the bundled NSXPCConnection(AuditToken) category.

NotificationManager.swift, SpotifyAppleScriptManager.swift
- Escape strings interpolated into AppleScript (backslash first, then quote) for the Messages send/tapback/mark-read scripts and the Spotify play-track URI, preventing AppleScript-literal breakout from remote-influenced text.

logReader.sh
- Quote the previously unquoted $syslog/$type/$id expansions in the device branch.

Note: these are partial mitigations for a broader audit. The updater change does not yet pin an exact designated requirement / notarization / signed manifest, and the helper still authorizes callers by Team ID rather than an exact designated requirement. Tracked separately.